### PR TITLE
Callable iocsh scripts

### DIFF
--- a/iocsh/autosaveBuild.iocsh
+++ b/iocsh/autosaveBuild.iocsh
@@ -3,8 +3,6 @@
 #- ###################################################
 #- PREFIX         - IOC Prefix
 #- SAVE_PATH      - Location of auto_positions, auto_settings, and autosave directory 
-#- POSITIONS_FILE - Name of positions req file
-#- SETTINGS_FILE  - Name of settings req file
 #- AUTOSAVE       - Location of Autosave module
 #-
 #- INCOMPLETE     - Optional: Ok to save/restore save sets with missing values?
@@ -52,13 +50,23 @@ dbLoadRecords("$(AUTOSAVE)/asApp/Db/save_restoreStatus.db", "P=$(PREFIX), DEAD_S
 #- Specify what save files should be restored.  Note these files must be
 #- in the directory specified in set_savefile_path(), or, if that function
 #- has not been called, from the directory current when iocInit is invoked
-set_pass0_restoreFile("$(POSITIONS_FILE)")
-set_pass0_restoreFile("$(SETTINGS_FILE)")
-set_pass1_restoreFile("$(SETTINGS_FILE)")
+set_pass0_restoreFile("built_positions.req")
+set_pass0_restoreFile("built_settings.req")
+set_pass1_restoreFile("built_settings.req")
 
 #- Note doAfterIocInit() supplied by std module.
-doAfterIocInit("create_monitor_set('$(POSITIONS_FILE)',$(POSITION_PERIOD=5),'P=$(PREFIX)')")
-doAfterIocInit("create_monitor_set('$(SETTINGS_FILE)',$(SETTING_PERIOD=30),'P=$(PREFIX)')")
+doAfterIocInit("create_monitor_set('built_positions.req',$(POSITION_PERIOD=5))")
+doAfterIocInit("create_monitor_set('built_settings.req',$(SETTING_PERIOD=30))")
 
 #- Debug-output level
 save_restoreSet_Debug(0)
+
+#- Tell autosave to automatically build built_settings.req and
+#- built_positions.req from databases and macros supplied to dbLoadRecords()
+#- (and dbLoadTemplate(), which calls dbLoadRecords()).
+#- This requires EPICS 3.15.1 or later, or 3.14 patched as described in
+#- autosave R5-5 documentation.
+epicsEnvSet("BUILT_SETTINGS", "built_settings.req")
+epicsEnvSet("BUILT_POSITIONS", "built_positions.req")
+autosaveBuild("$(BUILT_SETTINGS)", "_settings.req", 1)
+autosaveBuild("$(BUILT_POSITIONS)", "_positions.req", 1)

--- a/iocsh/autosaveBuild.iocsh
+++ b/iocsh/autosaveBuild.iocsh
@@ -1,51 +1,14 @@
-# ### save_restore.iocsh ###
+# ### autosaveBuild.iocsh ###
 
 #- ###################################################
 #- PREFIX         - IOC Prefix
-#- SAVE_PATH      - Location of auto_positions, auto_settings, and autosave directory 
 #- AUTOSAVE       - Location of Autosave module
-#-
-#- INCOMPLETE     - Optional: Ok to save/restore save sets with missing values?
-#-                  Default: 1
-#-
-#- DATED_BACKUP   - Optional: Save dated backup files?
-#-                  Default: 1
-#-
-#- CA_RECONNECT   - Optional: Retry connecting to PVs whose initial connection attempt failed?
-#-                  Default: 1
-#-
-#- NUM_SEQ        - Optional: Number of sequenced backup files to write
-#-                  Default: 3
-#-
-#- SEQ_PERIOD     - Optional: Time interval in seconds between sequenced backups
-#-                - Default: 300
-#-
 #- POSITION_PERIOD- Optional: Time interval in seconds between saving positions
 #-                - Default: 5
 #- 
 #- SETTING_PERIOD - Optional: Time interval in seconds between saving settings
 #-                - Default: 30
 #- ###################################################
-
-
-set_savefile_path("$(SAVE_PATH)", "autosave")
-
-#- Add save path and autosave to list of directories to find files
-set_requestfile_path("$(SAVE_PATH)", "")
-set_requestfile_path("$(AUTOSAVE)", "asApp/Db")
-
-save_restoreSet_status_prefix("$(PREFIX)")
-save_restoreSet_CAReconnect($(CA_RECONNECT=1))
-save_restoreSet_IncompleteSetsOk($(INCOMPLETE=1))
-save_restoreSet_DatedBackupFiles($(DATED_BACKUP=1))
-save_restoreSet_NumSeqFiles($(NUM_SEQ=3))
-save_restoreSet_SeqPeriodInSeconds($(SEQ_PERIOD=300))
-
-#- Time interval in seconds between forced save-file writes.  (-1 means forever).
-#- This is intended to get save files written even if the normal trigger mechanism is broken.
-save_restoreSet_CallbackTimeout(-1)
-
-dbLoadRecords("$(AUTOSAVE)/asApp/Db/save_restoreStatus.db", "P=$(PREFIX), DEAD_SECONDS=5")
 
 #- Specify what save files should be restored.  Note these files must be
 #- in the directory specified in set_savefile_path(), or, if that function
@@ -55,8 +18,8 @@ set_pass0_restoreFile("built_settings.req")
 set_pass1_restoreFile("built_settings.req")
 
 #- Note doAfterIocInit() supplied by std module.
-doAfterIocInit("create_monitor_set('built_positions.req',$(POSITION_PERIOD=5))")
-doAfterIocInit("create_monitor_set('built_settings.req',$(SETTING_PERIOD=30))")
+doAfterIocInit("create_monitor_set('built_positions.req',$(POSITION_PERIOD=5), PREFIX=$(PREFIX))")
+doAfterIocInit("create_monitor_set('built_settings.req',$(SETTING_PERIOD=30), PREFIX=$(PREFIX))")
 
 #- Debug-output level
 save_restoreSet_Debug(0)

--- a/iocsh/autosave_settings.iocsh
+++ b/iocsh/autosave_settings.iocsh
@@ -1,0 +1,40 @@
+# ### autosave_settings.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- AUTOSAVE       - Location of autosave module
+#- SAVE_PATH      - Location to create autosave directory where files will be saved
+#- INCOMPLETE     - Optional: Ok to save/restore save sets with missing values?
+#-                  Default: 1
+#-
+#- DATED_BACKUP   - Optional: Save dated backup files?
+#-                  Default: 1
+#-
+#- CA_RECONNECT   - Optional: Retry connecting to PVs whose initial connection attempt failed?
+#-                  Default: 1
+#-
+#- NUM_SEQ        - Optional: Number of sequenced backup files to write
+#-                  Default: 3
+#-
+#- SEQ_PERIOD     - Optional: Time interval in seconds between sequenced backups
+#-                - Default: 300
+#- ###################################################
+
+set_savefile_path("$(SAVE_PATH)", "autosave")
+
+#- Add save path and autosave to list of directories to find files
+set_requestfile_path("$(SAVE_PATH)", "")
+set_requestfile_path("$(AUTOSAVE)", "asApp/Db")
+
+save_restoreSet_status_prefix("$(PREFIX)")
+save_restoreSet_CAReconnect($(CA_RECONNECT=1))
+save_restoreSet_IncompleteSetsOk($(INCOMPLETE=1))
+save_restoreSet_DatedBackupFiles($(DATED_BACKUP=1))
+save_restoreSet_NumSeqFiles($(NUM_SEQ=3))
+save_restoreSet_SeqPeriodInSeconds($(SEQ_PERIOD=300))
+
+#- Time interval in seconds between forced save-file writes.  (-1 means forever).
+#- This is intended to get save files written even if the normal trigger mechanism is broken.
+save_restoreSet_CallbackTimeout(-1)
+
+dbLoadRecords("$(AUTOSAVE)/asApp/Db/save_restoreStatus.db", "P=$(PREFIX), DEAD_SECONDS=5")

--- a/iocsh/configMenu.iocsh
+++ b/iocsh/configMenu.iocsh
@@ -1,0 +1,16 @@
+# ### configMenu.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#- CONFIG         - Menu name, will search for $(CONFIG)Menu.req
+#- AUTOSAVE       - Location of autosave module
+#- ###################################################
+
+#- configMenu example.
+dbLoadRecords("$(AUTOSAVE)/asApp/Db/configMenu.db","P=$(PREFIX),CONFIG=$(CONFIG)")
+
+#- Note that the request file MUST be named $(CONFIG)Menu.req
+#- If the macro CONFIGMENU is defined with any value, backup (".savB") and
+#- sequence files (".savN") will not be written.  We don't want these for configMenu.
+#- Run this after iocInit:
+doAfterIocInit("create_manual_set('$(CONFIG)Menu.req','P=$(PREFIX),CONFIG=$(CONFIG),CONFIGMENU=1')")

--- a/iocsh/save_restore.iocsh
+++ b/iocsh/save_restore.iocsh
@@ -1,0 +1,70 @@
+# ### save_restore.iocsh ###
+
+#- ###################################################
+#- PREFIX         - IOC Prefix
+#  SAVE_PATH      - Location of auto_positions, auto_settings, and autosave directory 
+#- AUTOSAVE       - Location of Autosave module
+#-
+#- STD            - Optional: Location of STD module (if built into IOC)
+#-
+#- INCOMPLETE     - Optional: Ok to save/restore save sets with missing values?
+#-                  Default: 1
+#-
+#- DATED_BACKUP   - Optional: Save dated backup files?
+#-                  Default: 1
+#-
+#- CA_RECONNECT   - Optional: Retry connecting to PVs whose initial connection attempt failed?
+#-                  Default: 1
+#-
+#- NUM_SEQ        - Optional: Number of sequenced backup files to write
+#-                  Default: 3
+#-
+#- SEQ_PERIOD     - Optional: Time interval in seconds between sequenced backups
+#-                - Default: 300
+#-
+#- POSITION_PERIOD- Optional: Time interval in seconds between saving positions
+#-                - Default: 5
+#- 
+#- SETTING_PERIOD - Optional: Time interval in seconds between saving settings
+#-                - Default: 30
+#- ###################################################
+
+
+set_savefile_path("$(SAVE_PATH)", "autosave")
+
+save_restoreSet_status_prefix("$(PREFIX)")
+save_restoreSet_CAReconnect($(CA_RECONNECT=1))
+save_restoreSet_IncompleteSetsOk($(INCOMPLETE=1))
+save_restoreSet_DatedBackupFiles($(DATED_BACKUP=1))
+save_restoreSet_NumSeqFiles($(NUM_SEQ=3))
+save_restoreSet_SeqPeriodInSeconds($(SEQ_PERIOD=300))
+
+#- Time interval in seconds between forced save-file writes.  (-1 means forever).
+#- This is intended to get save files written even if the normal trigger mechanism is broken.
+save_restoreSet_CallbackTimeout(-1)
+
+dbLoadRecords("$(AUTOSAVE)/asApp/Db/save_restoreStatus.db", "P=$(PREFIX), DEAD_SECONDS=5")
+
+#- Specify what save files should be restored.  Note these files must be
+#- in the directory specified in set_savefile_path(), or, if that function
+#- has not been called, from the directory current when iocInit is invoked
+set_pass0_restoreFile("auto_positions.sav")
+set_pass0_restoreFile("auto_settings.sav")
+set_pass1_restoreFile("auto_settings.sav")
+
+#- Note doAfterIocInit() supplied by std module.
+doAfterIocInit("create_monitor_set('auto_positions.req',$(POSITION_PERIOD=5),'P=$(PREFIX)')")
+doAfterIocInit("create_monitor_set('auto_settings.req',$(SETTING_PERIOD=30),'P=$(PREFIX)')")
+
+#- Debug-output level
+save_restoreSet_Debug(0)
+
+#- Tell autosave to automatically build built_settings.req and
+#- built_positions.req from databases and macros supplied to dbLoadRecords()
+#- (and dbLoadTemplate(), which calls dbLoadRecords()).
+#- This requires EPICS 3.15.1 or later, or 3.14 patched as described in
+#- autosave R5-5 documentation.
+epicsEnvSet("BUILT_SETTINGS", "built_settings.req")
+epicsEnvSet("BUILT_POSITIONS", "built_positions.req")
+autosaveBuild("$(BUILT_SETTINGS)", "_settings.req", 1)
+autosaveBuild("$(BUILT_POSITIONS)", "_positions.req", 1)

--- a/iocsh/save_restore.iocsh
+++ b/iocsh/save_restore.iocsh
@@ -2,7 +2,9 @@
 
 #- ###################################################
 #- PREFIX         - IOC Prefix
-#  SAVE_PATH      - Location of auto_positions, auto_settings, and autosave directory 
+#- SAVE_PATH      - Location of auto_positions, auto_settings, and autosave directory 
+#- POSITION_FILE  - Name of positions.sav file
+#- SETTING_FILE   - Name of settings.sav file 
 #- AUTOSAVE       - Location of Autosave module
 #-
 #- STD            - Optional: Location of STD module (if built into IOC)
@@ -32,6 +34,10 @@
 
 set_savefile_path("$(SAVE_PATH)", "autosave")
 
+#- Add save path and autosave to list of directories to find files
+set_requestfile_path("$(SAVE_PATH)", "")
+set_requestfile_path("$(AUTOSAVE)", "asApp/Db")
+
 save_restoreSet_status_prefix("$(PREFIX)")
 save_restoreSet_CAReconnect($(CA_RECONNECT=1))
 save_restoreSet_IncompleteSetsOk($(INCOMPLETE=1))
@@ -48,9 +54,9 @@ dbLoadRecords("$(AUTOSAVE)/asApp/Db/save_restoreStatus.db", "P=$(PREFIX), DEAD_S
 #- Specify what save files should be restored.  Note these files must be
 #- in the directory specified in set_savefile_path(), or, if that function
 #- has not been called, from the directory current when iocInit is invoked
-set_pass0_restoreFile("auto_positions.sav")
-set_pass0_restoreFile("auto_settings.sav")
-set_pass1_restoreFile("auto_settings.sav")
+set_pass0_restoreFile("$(POSITION_FILE)")
+set_pass0_restoreFile("$(SETTING_FILE)")
+set_pass1_restoreFile("$(SETTING_FILE)")
 
 #- Note doAfterIocInit() supplied by std module.
 doAfterIocInit("create_monitor_set('auto_positions.req',$(POSITION_PERIOD=5),'P=$(PREFIX)')")

--- a/iocsh/save_restore.iocsh
+++ b/iocsh/save_restore.iocsh
@@ -3,8 +3,8 @@
 #- ###################################################
 #- PREFIX         - IOC Prefix
 #- SAVE_PATH      - Location of auto_positions, auto_settings, and autosave directory 
-#- POSITIONS_FILE - Name of positions req file
-#- SETTINGS_FILE  - Name of settings req file
+#- POSITIONS_FILE - Name of positions req file, macro PREFIX will be defined for the file
+#- SETTINGS_FILE  - Name of settings req file, macro PREFIX will be defined for the file
 #- AUTOSAVE       - Location of Autosave module
 #-
 #- INCOMPLETE     - Optional: Ok to save/restore save sets with missing values?
@@ -57,8 +57,8 @@ set_pass0_restoreFile("$(SETTINGS_FILE)")
 set_pass1_restoreFile("$(SETTINGS_FILE)")
 
 #- Note doAfterIocInit() supplied by std module.
-doAfterIocInit("create_monitor_set('$(POSITIONS_FILE)',$(POSITION_PERIOD=5),'P=$(PREFIX)')")
-doAfterIocInit("create_monitor_set('$(SETTINGS_FILE)',$(SETTING_PERIOD=30),'P=$(PREFIX)')")
+doAfterIocInit("create_monitor_set('$(POSITIONS_FILE)',$(POSITION_PERIOD=5),'PREFIX=$(PREFIX)')")
+doAfterIocInit("create_monitor_set('$(SETTINGS_FILE)',$(SETTING_PERIOD=30),'PREFIX=$(PREFIX)')")
 
 #- Debug-output level
 save_restoreSet_Debug(0)

--- a/iocsh/save_restore.iocsh
+++ b/iocsh/save_restore.iocsh
@@ -5,8 +5,6 @@
 #- SAVE_PATH      - Location of auto_positions, auto_settings, and autosave directory 
 #- AUTOSAVE       - Location of Autosave module
 #-
-#- STD            - Optional: Location of STD module (if built into IOC)
-#-
 #- INCOMPLETE     - Optional: Ok to save/restore save sets with missing values?
 #-                  Default: 1
 #-

--- a/iocsh/save_restore.iocsh
+++ b/iocsh/save_restore.iocsh
@@ -2,52 +2,15 @@
 
 #- ###################################################
 #- PREFIX         - IOC Prefix
-#- SAVE_PATH      - Location of auto_positions, auto_settings, and autosave directory 
 #- POSITIONS_FILE - Name of positions req file, macro PREFIX will be defined for the file
 #- SETTINGS_FILE  - Name of settings req file, macro PREFIX will be defined for the file
 #- AUTOSAVE       - Location of Autosave module
-#-
-#- INCOMPLETE     - Optional: Ok to save/restore save sets with missing values?
-#-                  Default: 1
-#-
-#- DATED_BACKUP   - Optional: Save dated backup files?
-#-                  Default: 1
-#-
-#- CA_RECONNECT   - Optional: Retry connecting to PVs whose initial connection attempt failed?
-#-                  Default: 1
-#-
-#- NUM_SEQ        - Optional: Number of sequenced backup files to write
-#-                  Default: 3
-#-
-#- SEQ_PERIOD     - Optional: Time interval in seconds between sequenced backups
-#-                - Default: 300
-#-
 #- POSITION_PERIOD- Optional: Time interval in seconds between saving positions
 #-                - Default: 5
 #- 
 #- SETTING_PERIOD - Optional: Time interval in seconds between saving settings
 #-                - Default: 30
 #- ###################################################
-
-
-set_savefile_path("$(SAVE_PATH)", "autosave")
-
-#- Add save path and autosave to list of directories to find files
-set_requestfile_path("$(SAVE_PATH)", "")
-set_requestfile_path("$(AUTOSAVE)", "asApp/Db")
-
-save_restoreSet_status_prefix("$(PREFIX)")
-save_restoreSet_CAReconnect($(CA_RECONNECT=1))
-save_restoreSet_IncompleteSetsOk($(INCOMPLETE=1))
-save_restoreSet_DatedBackupFiles($(DATED_BACKUP=1))
-save_restoreSet_NumSeqFiles($(NUM_SEQ=3))
-save_restoreSet_SeqPeriodInSeconds($(SEQ_PERIOD=300))
-
-#- Time interval in seconds between forced save-file writes.  (-1 means forever).
-#- This is intended to get save files written even if the normal trigger mechanism is broken.
-save_restoreSet_CallbackTimeout(-1)
-
-dbLoadRecords("$(AUTOSAVE)/asApp/Db/save_restoreStatus.db", "P=$(PREFIX), DEAD_SECONDS=5")
 
 #- Specify what save files should be restored.  Note these files must be
 #- in the directory specified in set_savefile_path(), or, if that function

--- a/iocsh/save_restore.iocsh
+++ b/iocsh/save_restore.iocsh
@@ -3,8 +3,6 @@
 #- ###################################################
 #- PREFIX         - IOC Prefix
 #- SAVE_PATH      - Location of auto_positions, auto_settings, and autosave directory 
-#- POSITION_FILE  - Name of positions.sav file
-#- SETTING_FILE   - Name of settings.sav file 
 #- AUTOSAVE       - Location of Autosave module
 #-
 #- STD            - Optional: Location of STD module (if built into IOC)
@@ -54,9 +52,9 @@ dbLoadRecords("$(AUTOSAVE)/asApp/Db/save_restoreStatus.db", "P=$(PREFIX), DEAD_S
 #- Specify what save files should be restored.  Note these files must be
 #- in the directory specified in set_savefile_path(), or, if that function
 #- has not been called, from the directory current when iocInit is invoked
-set_pass0_restoreFile("$(POSITION_FILE)")
-set_pass0_restoreFile("$(SETTING_FILE)")
-set_pass1_restoreFile("$(SETTING_FILE)")
+set_pass0_restoreFile("built_positions.req")
+set_pass0_restoreFile("built_settings.req")
+set_pass1_restoreFile("built_settings.req")
 
 #- Note doAfterIocInit() supplied by std module.
 doAfterIocInit("create_monitor_set('auto_positions.req',$(POSITION_PERIOD=5),'P=$(PREFIX)')")


### PR DESCRIPTION
Added iocsh script that takes in a path to put save files and sets up the autobuild system, sets defaults for various autosave settings, and starts the necessary monitor processes. All the user needs to do is add the directories to search for req files.