### PR TITLE
make requestfile and macrostring together to identify a unique data set

### DIFF
--- a/asApp/src/configMenuClient.h
+++ b/asApp/src/configMenuClient.h
@@ -4,7 +4,7 @@
 typedef void (*callbackFunc)(int status, void *puserPvt);
 extern int fdbrestoreX(char *filename, char *macrostring, callbackFunc callbackFunction, void *puserPvt);
 extern char *getMacroString(char *request_file);
-extern int manual_save(char *request_file, char *save_file, callbackFunc callbackFunction, void *puserPvt);
+extern int manual_save(char *request_file, char *macrostring, char *save_file, callbackFunc callbackFunction, void *puserPvt);
 extern int findConfigFiles(char *config, ELLLIST *configMenuList);
 
 struct configFileListItem {

--- a/asApp/src/configMenuSub.c
+++ b/asApp/src/configMenuSub.c
@@ -100,9 +100,12 @@ static long configMenu_do(aSubRecord *pasub) {
 				*valc = 1;
 				return(0);
 			}
+			if (f) {
+				macrostring = getMacroString(f);
+			}
 			makeLegal(a);
 			epicsSnprintf(filename, 99, "%s_%s.cfg", g, a);
-			*b = (epicsInt32)manual_save(f, filename, configMenuCallback, (void *)pasub);
+			*b = (epicsInt32)manual_save(f, macrostring, filename, configMenuCallback, (void *)pasub);
 			if (configMenuDebug) printf("configMenu_do:manual_save returned %d\n", *b);
 			*vala = 1;
 			*valb = 1;


### PR DESCRIPTION
The backgroud: I want to define a standard startup script for an epics driver.
```
  # file st.cmd.dum
  dumAsynPortConfig("DUM$(N=1)")
  dbLoadRecords("dum.db", "P=XW$(N=1):")
  set_pass0_restoreFile("dum_settings$(N=1).sav")
  # afterInit is an iocsh command to run the command after iocInit
  afterInit create_monitor_set("dum_settings.req",10,"P=XW$(N=1):","dum_settings$(N=1).sav")
```
And then the user script only needs to define macro N and can load the driver multiple times
```
  # file st.cmd
  < st.cmd.dum
  epicsEnvSet("N","2")
  < st.cmd.dum
  epicsEnvSet("N","3")
  < st.cmd.dum
```

The current version of autosave would refuse to load the same requestfile twice, even the actual PVs
are different because of different macrostring. The proposed change is to make requestfile and
macrostring together to identify the data set.
Changed(backwards compatible):
 * when search for a dataset, always match both requestfile and macrostring
 * appended a savefile argument for function create_xxx_set. If specified, this will be used for
 savefile name. Otherwise, the savefile name is created from requestfile like before.
 * appended a macrostring argument for function manual_save and remove_data_set. If left empty, the first match
 of requestfile will be saved.

Not done(breaks):
 * getMacroString assumes one requestfile has only one macrostring
 * configMenu does not take macrostring input