### PR TITLE
for enums save number and string

### DIFF
--- a/asApp/src/save_restore.c
+++ b/asApp/src/save_restore.c
@@ -1782,7 +1782,15 @@ STATIC int write_it(char *filename, struct chlist *plist)
 		if (pchannel->curr_elements <= 1) {
 			/* treat as scalar */
 			if (pchannel->enum_val >= 0) {
-				n = fprintf(out_fd, "%d\n",pchannel->enum_val);
+				/*
+				** The channel would appear to be of type ENUM. Save the
+				** equivalent string too, if it is non-blank.
+				*/
+				if (strlen (pchannel->value) > 0) {
+					n = fprintf(out_fd, "%s %d \"%s\"\n", ENUM_MARKER, pchannel->enum_val, pchannel->value);
+				} else {
+					n = fprintf(out_fd, "%d\n",pchannel->enum_val);
+				}
 			} else {
 				n = fprintf(out_fd, "%-s\n", pchannel->value);
 			}

--- a/asApp/src/save_restore.h
+++ b/asApp/src/save_restore.h
@@ -54,6 +54,8 @@ static char SR_STATUS_STR[5][10] =
 #define ESCAPE '\\'
 #define ARRAY_MARKER "@array@"
 #define ARRAY_MARKER_LEN 7
+#define ENUM_MARKER "@enum@"
+#define ENUM_MARKER_LEN 6
 
 #define FN_LEN 80 /* filename length */
 #define STRING_LEN MAX_STRING_SIZE	/* EPICS max length for string PV */


### PR DESCRIPTION
This patch saves enums as index number and string. During restore, it tries to restore the string first. Only if that fails, it restored the index number. This can make a difference if new choices are inserted in the middle or choices are re-ordered. Examples are new breakpoint tables for the LINR field inserted in some other order than the date of implementation (e.g. alphabetically). The idea is that if the enum sorting changes, people usually want to have the old string choice restored (the user interface of enums), not the index number (the implementation). 

This modification has originally been implemented by David Maden at SLS in 2005.