### PR TITLE
Fix file name passed to set _pass[01]_restoreFile.

### DIFF
--- a/documentation/autoSaveRestore.html
+++ b/documentation/autoSaveRestore.html
@@ -317,8 +317,8 @@ and which are to be restored after record initialization (pass 1), using the
 commands set_pass&lt;N&gt;_restoreFile(), as in this example:
 
 <pre>
-	set_pass0_restoreFile("auto_settings.req", "P=xxx:")
-	set_pass1_restoreFile("auto_settings.req", "P=xxx:")
+	set_pass0_restoreFile("auto_settings.sav", "P=xxx:")
+	set_pass1_restoreFile("auto_settings.sav", "P=xxx:")
 </pre>
 
 (Note the macrostring is optional, and a new feature of autosave 5.4.)


### PR DESCRIPTION
Part of the documentation wrongly states that the .req file should be passed to set _pass[01]_restoreFile.