### PR TITLE
V7 fix

### DIFF
--- a/asApp/src/save_restore.c
+++ b/asApp/src/save_restore.c
@@ -1850,18 +1850,18 @@ STATIC int write_it(char *filename, struct chlist *plist)
 		}
 
 		errno = 0;
-		if (pchannel->curr_elements <= 1) {
+		if (is_long_string) {
+			/* write first BUF-SIZE-1 characters of long string, so dbrestore doesn't choke. */
+			strNcpy(value_string, pchannel->pArray, BUF_SIZE);
+			value_string[BUF_SIZE-1] = '\0';
+			n = fprintf(out_fd, "%-s\n", value_string);
+		} else if (pchannel->curr_elements <= 1) {
 			/* treat as scalar */
 			if (pchannel->enum_val >= 0) {
 				n = fprintf(out_fd, "%d\n",pchannel->enum_val);
 			} else {
 				n = fprintf(out_fd, "%-s\n", pchannel->value);
 			}
-		} else if (is_long_string) {
-			/* write first BUF-SIZE-1 characters of long string, so dbrestore doesn't choke. */
-			strNcpy(value_string, pchannel->pArray, BUF_SIZE);
-			value_string[BUF_SIZE-1] = '\0';
-			n = fprintf(out_fd, "%-s\n", value_string);
 		} else {
 			/* treat as array */
 			n = SR_write_array_data(out_fd, pchannel->name, (void *)pchannel->pArray, pchannel->curr_elements);

--- a/documentation/autosaveReleaseNotes.html
+++ b/documentation/autosaveReleaseNotes.html
@@ -13,9 +13,12 @@ content="text/html; charset=iso-8859-1">
 <h3>5.10</h3>
 <ul>
 
-<li>Added the user callable function save_restoreSet_periodicDatedBackups(periodInMinutes).
+<li>Added the user callable function save_restoreSet_periodicDatedBackups(periodInMinutes).</li>
 
-<li>Added PVs SR_disable and SR_disableMaxSecs.
+<li>Added PVs SR_disable and SR_disableMaxSecs.</li>
+
+<li>Fixed problem with new versions of base (7.x, 3.15.6). 
+  Empty long string fields were being saved as the string "0", rather than an empty string.</li>
 
 </ul>
 


### PR DESCRIPTION
Fixed a problem with saving empty long strings with new versions of base (e.g. 7.x and future 3.15.6).

dbGet now returns the actual string length rather than the maximum string length.  That was causing save_restore::write_it to write the string "0" into the autosave file, rather than an empty string.  Changed the logic to fix this.