### PR TITLE
Fix restore of long strings on IOC startup

### DIFF
--- a/asApp/src/dbrestore.c
+++ b/asApp/src/dbrestore.c
@@ -214,7 +214,7 @@ STATIC int myFileCopy(const char *source, const char *dest)
 }
 
 
-STATIC long scalar_restore(int pass, DBENTRY *pdbentry, char *PVname, char *value_string)
+STATIC long scalar_restore(int pass, DBENTRY *pdbentry, char *PVname, char *value_string, int is_long_string)
 {
 	long 	n, status = 0;
 	DBADDR	dbaddr;
@@ -271,7 +271,11 @@ STATIC long scalar_restore(int pass, DBENTRY *pdbentry, char *PVname, char *valu
 		if (pass == 1) {
 			status = dbNameToAddr(PVname, paddr);
 			if (!status) {
-				status = dbPut(paddr, DBR_STRING, value_string, 1);
+				if (is_long_string && paddr->field_type == DBF_CHAR) {
+					status = dbPut(paddr, DBF_CHAR, value_string, strlen(value_string) + 1);
+				} else {
+					status = dbPut(paddr, DBF_STRING, value_string, 1);
+				}
 			}
 		} else if (save_restoreDebug > 1) {
 			errlogPrintf("dbrestore:scalar_restore: Can't restore DBF_NOACCESS field (%s) in pass 0.\n", PVname);
@@ -984,7 +988,7 @@ int reboot_restore(char *filename, initHookState init_state)
 			}
 			if (found_field) {
 				if (is_scalar || is_long_string) {
-					status = scalar_restore(pass, pdbentry, PVname, value_string);
+					status = scalar_restore(pass, pdbentry, PVname, value_string, is_long_string);
 				} else {
 					status = SR_array_restore(pass, inp_fd, PVname, value_string, 0);
 				}


### PR DESCRIPTION
Autosave had a bug that made it impossible to restore the value of an lso record, when pointing to `recordName.VAL$`. The restore operation would fail with "No digits to convert". It would work when using `recordName.VAL`, but in this case the string would be truncated to 39 characters.

This patch fixes this problem, so that now `recordName.VAL$` can be used in order to save & restore long strings. This patch only affects the restore operation during IOC startup, not manual restores. I have not tested it, but it might be that manual restores already worked because they use an entirely different code path.