### PR TITLE
Print a message if the requestFileCmd is too long.

### DIFF
--- a/asApp/src/dbrestore.c
+++ b/asApp/src/dbrestore.c
@@ -1640,7 +1640,12 @@ static void myDbLoadRecordsHook(const char* fname, const char* macro) {
 					}
 				}
 				n = epicsSnprintf(requestFileCmd, MAXSTRING, "file %s %s", requestFileName, macroString);
-				if (n < MAXSTRING) appendToFile(pitem->filename, requestFileCmd);
+				if (n < MAXSTRING) {
+					appendToFile(pitem->filename, requestFileCmd);
+				} else {
+					printf("myDbLoadRecordsHook: Can't include %s; requestFileCmd is too long (n = %i, MAXSTRING = %i)\n", 
+					requestFileName, n, MAXSTRING);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #32 