### PR TITLE
Added -V flag to asVerify, and fixed a segmentation fault

### DIFF
--- a/asApp/src/Makefile
+++ b/asApp/src/Makefile
@@ -26,6 +26,7 @@ DBD += asSupport.dbd
 
 #include files
 INC += osdNfs.h
+INC += autosave_release.h
 
 #=============================
 
@@ -46,3 +47,6 @@ include $(TOP)/configure/RULES
 #  ADD RULES AFTER THIS LINE
 
 dbrestore.o:   ../Makefile
+
+$(COMMON_DIR)/autosave_release.h: $(TOP)/configure/CONFIG ../autosave_release.pl
+	$(PERL) ../autosave_release.pl $(AUTOSAVE_RELEASE) > $@

--- a/asApp/src/asVerify.c
+++ b/asApp/src/asVerify.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <unistd.h>
+#include <epicsGetopt.h>
 
 #include <ctype.h> /* isalpha */
 #include <math.h> /* fabs */

--- a/asApp/src/asVerify.c
+++ b/asApp/src/asVerify.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <ctype.h> /* isalpha */
 #include <math.h> /* fabs */
@@ -13,6 +14,7 @@
 #include "cadef.h"
 
 #include "save_restore.h"
+#include "autosave_release.h"
 
 
 
@@ -42,6 +44,9 @@ void printUsage(void) {
 	fprintf(stderr,"that occur in a .req file.  (It will look for a PV named 'file'.)\n");
 }
 
+void printVersion(void) {
+	printf("asVerify, built from %s\n", AUTOSAVE_RELEASE);
+}
 
 int main(int argc,char **argv)
 {
@@ -52,23 +57,24 @@ int main(int argc,char **argv)
 	int		numDifferences;
 	int		status;
 	int		verbose=0, debug=0, write_restore_file=0;
+	int		opt;
 
-	/* Parse args */
-	if (argc == 1) {
+	while ((opt = getopt(argc, argv, "Vvrdh")) != -1) {
+		switch (opt) {
+			case 'V': printVersion(); exit(0);
+			case 'v': verbose = 1; break;
+			case 'r': write_restore_file = 1; break;
+			case 'd': printf("debug=%d\n", ++debug); break;
+			case 'h': printUsage(); exit(1);
+		}
+	}
+
+	if (argc <= optind) {
 		printUsage();
 		exit(1);
 	}
-	if (*argv[1] == '-') {
-		for (n=1; n<strlen(argv[1]); n++) {
-			if (argv[1][n] == 'v') verbose = 1;
-			if (argv[1][n] == 'r') write_restore_file = 1;
-			if (argv[1][n] == 'd') printf("debug=%d\n", ++debug);
-			if (argv[1][n] == 'h') {printUsage(); exit(1);}
-		}
-		strcpy(filename, argv[2]);
-	} else {
-		strcpy(filename, argv[1]);
-	}
+
+	strcpy(filename, argv[optind]);
 
 	status = ca_context_create(ca_disable_preemptive_callback);
 	if (!(status & CA_M_SUCCESS)) {

--- a/asApp/src/autosave_release.pl
+++ b/asApp/src/autosave_release.pl
@@ -1,0 +1,7 @@
+#!/usr/bin/perl
+#
+# create the autosave release header file
+#
+$release = $ARGV[0];
+$now = localtime;
+print "#define AUTOSAVE_RELEASE \"Autosave release $release, compiled $now\"\n";

--- a/configure/CONFIG
+++ b/configure/CONFIG
@@ -28,3 +28,4 @@ ifdef T_A
  -include $(TOP)/configure/CONFIG_SITE.$(EPICS_HOST_ARCH).$(T_A)
 endif
 
+AUTOSAVE_RELEASE = 5.10.3


### PR DESCRIPTION
Previously, if you ran `asVerify` with no filename, i.e. any of the
following:
```
$ asVerify
$ asVerify -v
$ asVerify -
```
you would get a segmentation fault due to the `strcpy` reaching beyond
the length of `argv`. This fixes this issue, as well as adding a `-V`
(for version) flag allowing one to test the existence of this utility.