### PR TITLE
Detect error in epicsStrPrintEscaped

### DIFF
--- a/asApp/src/save_restore.c
+++ b/asApp/src/save_restore.c
@@ -1884,14 +1884,18 @@ STATIC int write_it(char *filename, struct chlist *plist)
 			strNcpy(value_string, pchannel->pArray, BUF_SIZE);
 			value_string[BUF_SIZE-1] = '\0';
 			n = epicsStrPrintEscaped(out_fd, value_string, strlen(value_string));
-			n = fprintf(out_fd, "\n");
+			if (n > 0 || !strlen(value_string)) {
+				n = fprintf(out_fd, "\n");
+			}
 		} else if (pchannel->curr_elements <= 1) {
 			/* treat as scalar */
 			if (pchannel->enum_val >= 0) {
 				n = fprintf(out_fd, "%d\n",pchannel->enum_val);
 			} else {
 				n = epicsStrPrintEscaped(out_fd, pchannel->value, strlen(pchannel->value));
-				n = fprintf(out_fd, "\n");
+				if (n > 0 || !strlen(pchannel->value)) {
+					n = fprintf(out_fd, "\n");
+				}
 			}
 		} else {
 			/* treat as array */


### PR DESCRIPTION
PR #29 introduced the use of `epicsStrPrintEscaped` so that line breaks in strings would be handled correctly. Unfortunately, this introduced a bug (#48) that would cause save attempts to fail when the string to be written was empty.

This bug was fixed with d1e46a23ddad4bf01281b06d65021ed4a788a409 and 3d69b3d9387bcaa4953d5a4d44bae636c5cfba46, but this introduced an issue where Autosave would assume success, even if `epicsStrPrintEscaped` failed to write anything, not because the string was empty, but because `fprintf` failed or some reason.

This commit reintroduces the check whether `epicsStrPrintEscaped` has written anything, but it now correctly handles the case where `epicsStrPrintEscaped` does not write anything because the string that it is supposed to write is empty.