### PR TITLE
write_it: do _commit after fflush for win32

### DIFF
--- a/asApp/src/save_restore.c
+++ b/asApp/src/save_restore.c
@@ -140,6 +140,7 @@
 #else
 #include    <windows.h>
 #include	"tr_dirent.h" /* for dirList */
+#include	<io.h> /* for _commit */
 #endif
 #include	<string.h>
 #include	<ctype.h>
@@ -1945,7 +1946,7 @@ STATIC int write_it(char *filename, struct chlist *plist)
 		if (errno) myPrintErrno("write_it", __FILE__, __LINE__);
 	}
 #elif defined(_WIN32)
-        /* WIN32 has no real equivalent to fsync? */
+	n = _commit(_fileno(out_fd)); /* Flush directly to disk, skip OS buffers */
 #else
 	n = fsync(fileno(out_fd));
 	if (n && (errno == ENOTSUP)) { n = 0; errno = 0; }


### PR DESCRIPTION
I saw the comment in there and was curious if win32 has some equivalent to fsync. [_commit](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/commit?view=msvc-170) seems to be functionally identical, so use that in `write_it`