### PR TITLE
Protect against deferencing null pointers in strNcpy macro

### DIFF
--- a/asApp/src/save_restore.h
+++ b/asApp/src/save_restore.h
@@ -116,12 +116,12 @@ extern int appendToFile(const char *filename, const char *line);
 extern float mySafeDoubleToFloat(double d);
 
 /* strncpy sucks (may copy extra characters, may not null-terminate) */
-#define strNcpy(dest, src, N)                                \
-    {                                                        \
-        int ii;                                              \
-        char *dd = dest;                                     \
-        const char *ss = src;                                \
-        for (ii = 0; *ss && ii < N - 1; ii++)                \
-            if (dd && ss) *dd++ = *ss++;                     \
-        *dd = '\0';                                          \
+#define strNcpy(dest, src, N)                                    \
+    {                                                            \
+        int ii;                                                  \
+        char *dd = dest;                                         \
+        const char *ss = src;                                    \
+        if (dd && ss)                                            \
+            for (ii = 0; *ss && ii < N - 1; ii++) *dd++ = *ss++; \
+        *dd = '\0';                                              \
     }

--- a/asApp/src/save_restore.h
+++ b/asApp/src/save_restore.h
@@ -116,7 +116,7 @@ extern int appendToFile(const char *filename, const char *line);
 extern float mySafeDoubleToFloat(double d);
 
 /* strncpy sucks (may copy extra characters, may not null-terminate) */
-#define strNcpy(dest, src, N)
+#define strNcpy(dest, src, N)                                \
     {                                                        \
         int ii;                                              \
         char *dd = dest;                                     \

--- a/asApp/src/save_restore.h
+++ b/asApp/src/save_restore.h
@@ -116,8 +116,9 @@ extern float mySafeDoubleToFloat(double d);
 	int ii;								\
 	char *dd=dest;						\
 	const char *ss=src;					\
-	for (ii=0; *ss && ii < N-1; ii++)	\
-		*dd++ = *ss++;					\
+	if (dd && ss) \
+	  for (ii=0; *ss && ii < N-1; ii++)	\
+		  *dd++ = *ss++;					\
 	*dd = '\0';							\
 }
 


### PR DESCRIPTION
I have been getting crashes here when writing some savefiles:
https://github.com/epics-modules/autosave/blob/606903e177790c6431b277d4393700d9e5991b26/asApp/src/save_restore.c#L1884

The problem is that the strNcpy macro does not protect against null pointers.  This PR fixes that.