### PR TITLE
Using dbr_field_type instead of field_type in SR_get_array

### DIFF
--- a/asApp/src/dbrestore.c
+++ b/asApp/src/dbrestore.c
@@ -1298,16 +1298,15 @@ long SR_get_array(char *PVname, void *pArray, long *pnum_elements)
     status = dbNameToAddr(PVname, paddr);
     if (status) return (status);
     dbScanLock((dbCommon *)paddr->precord);
-    request_field_type = paddr->field_type;
+    request_field_type = paddr->dbr_field_type;
     /*
 	 * Not clear what we should do if someone has an array of enums
 	 * or menu items.  For now, just do something that will work
 	 * in the simplest case.
 	 */
-    if ((request_field_type == DBF_ENUM) || (request_field_type == DBF_MENU)) {
-        errlogPrintf("save_restore:SR_get_array: field_type %s array read as DBF_USHORT\n",
-                     pamapdbfType[request_field_type].strvalue);
-        request_field_type = DBF_USHORT;
+    if (request_field_type == DBR_ENUM) {
+        errlogPrintf("save_restore:SR_get_array: field_type DBR_ENUM array read as DBR_USHORT\n");
+        request_field_type = DBR_USHORT;
     }
     status = dbGet(paddr, request_field_type, pArray, NULL, pnum_elements, NULL);
     if (save_restoreDebug >= 10) {


### PR DESCRIPTION
Copied from https://github.com/slac-epics/autosave/pull/2

Currently, autosave requests for long links (e.g., an input link with $ at the end) will never have any values in their sav files. This is because in SR_get_array, paddr->field_type is passed as as dbrType to dbGet.
https://github.com/slac-epics/autosave/blob/a98b30c7af7d7d93506786a7de61a75d31d15664/asApp/src/dbrestore.c#L1301C26-L1301C43
For DBF_INLINKS, DBF_OUTLINKS, and DBF_FWDLINKS, dbGet calls getLinkValue which also takes in dbrType as input. If you instead pass the DBF value for any link, you fall into this case that returns an error code and does not set your buffer to the value of the PV
https://github.com/slac-epics/epics-base/blob/308e234c41f59b9103b6d309f3256262a3175da2/modules/database/src/ioc/db/dbAccess.c#L819-L821

I have modified SR_get_array to instead use dbr_field_type, which is the value that I believe dbGet expects. For most types, dbr_field_type and field_type are the same, but not for links, which are mapped to DBR_STRING, and DBF_MENU and DBF_DEVICE, which are both mapped to DBR_ENUM.
https://github.com/slac-epics/epics-base/blob/308e234c41f59b9103b6d309f3256262a3175da2/modules/database/src/ioc/db/dbAccess.c#L75-L94