### PR TITLE
Refactor out NFS-related code from save_restore.c

### DIFF
--- a/asApp/src/Makefile
+++ b/asApp/src/Makefile
@@ -23,6 +23,7 @@ asVerify_LIBS	+= Com
 USR_CFLAGS += -DDBLOADRECORDSHOOKREGISTER
 
 DBD += asSupport.dbd
+DBD += asSupportNfs.dbd
 
 #include files
 INC += osdNfs.h
@@ -33,7 +34,7 @@ INC += autosave_release.h
 LIBRARY_IOC += autosave
 
 #os independent code
-autosave_SRCS += dbrestore.c save_restore.c
+autosave_SRCS += dbrestore.c save_restore.c nfs_utils.c
 autosave_SRCS += initHooks.c fGetDateStr.c
 autosave_SRCS += configMenuSub.c verify.c
 

--- a/asApp/src/asSupportNfs.dbd
+++ b/asApp/src/asSupportNfs.dbd
@@ -1,0 +1,1 @@
+registrar(save_restoreNFSRegister)

--- a/asApp/src/dbrestore.c
+++ b/asApp/src/dbrestore.c
@@ -810,7 +810,7 @@ int reboot_restore(char *filename, initHookState init_state)
     if (isAbsolute(filename)) {
         strNcpy(fname, filename, PATH_SIZE);
     } else {
-        makeNfsPath(fname, saveRestoreFilePath, filename);
+        concatenate_paths(fname, saveRestoreFilePath, filename);
     }
     if (save_restoreDebug)
         errlogPrintf("*** restoring from '%s' at initHookState %d (%s record/device init) ***\n", fname,

--- a/asApp/src/nfs_utils.c
+++ b/asApp/src/nfs_utils.c
@@ -1,5 +1,6 @@
 #include <iocsh.h>
 #include <epicsExport.h>
+#include <epicsStdio.h>
 
 #include "osdNfs.h"
 #include "save_restore_common.h"
@@ -93,6 +94,18 @@ void save_restoreSet_NFSHost(char *hostname, char *address, char *mntpoint)
 
     /* mount the file system */
     do_mount();
+}
+
+int nfs_managed()
+{
+    return save_restoreNFSHostName[0] && save_restoreNFSHostAddr[0] && save_restoreNFSMntPoint[0];
+}
+
+void save_restore_nfs_show()
+{
+    printf("  NFS host: '%s'; address:'%s'\n", save_restoreNFSHostName, save_restoreNFSHostAddr);
+    printf("  NFS mount point:\n    '%s'\n", save_restoreNFSMntPoint);
+    printf("  NFS mount status: %s\n", save_restoreNFSOK ? "Ok" : "Failed");
 }
 
 IOCSH_ARG save_restoreSet_NFSHost_Arg0 = {"hostname", iocshArgString};

--- a/asApp/src/nfs_utils.c
+++ b/asApp/src/nfs_utils.c
@@ -83,7 +83,7 @@ void save_restoreSet_NFSHost(char *hostname, char *address, char *mntpoint)
         if (saveRestoreFilePath[0]) {
             /* If we already have a file path, make sure it begins with the mount point. */
             if (strstr(saveRestoreFilePath, save_restoreNFSMntPoint) != saveRestoreFilePath) {
-                makeNfsPath(saveRestoreFilePath, save_restoreNFSMntPoint, saveRestoreFilePath);
+                concatenate_paths(saveRestoreFilePath, save_restoreNFSMntPoint, saveRestoreFilePath);
             }
         }
     } else if (saveRestoreFilePath[0]) {

--- a/asApp/src/nfs_utils.c
+++ b/asApp/src/nfs_utils.c
@@ -1,0 +1,114 @@
+#include <iocsh.h>
+#include <epicsExport.h>
+
+#include "osdNfs.h"
+#include "save_restore_common.h"
+#include "nfs_utils.h"
+
+char save_restoreNFSHostName[NFS_PATH_LEN] = "";
+char save_restoreNFSHostAddr[NFS_PATH_LEN] = "";
+char save_restoreNFSMntPoint[NFS_PATH_LEN] = "";
+int saveRestoreFilePathIsMountPoint = 1;
+volatile int save_restoreRemountThreshold = 10;
+
+epicsExportAddress(int, save_restoreRemountThreshold);
+
+STATIC int do_mount()
+{
+    if (mountFileSystem(save_restoreNFSHostName, save_restoreNFSHostAddr, save_restoreNFSMntPoint,
+                        save_restoreNFSMntPoint) == OK) {
+        /*
+         * NOTE: If NFS mounts are not supported this will take this
+         * code path (i.e. it returns OK [=0] and prints this message)
+         */
+        printf("save_restore:mountFileSystem:successfully mounted '%s'\n", save_restoreNFSMntPoint);
+        return OK;
+    }
+    printf("save_restore: Can't mount '%s'\n", save_restoreNFSMntPoint);
+    return ERROR;
+}
+
+int restore_mount(epicsTimeStamp remount_check_time, int *just_remounted)
+{
+    epicsTimeStamp currTime;
+    double timeDiff;
+
+    epicsTimeGetCurrent(&currTime);
+
+    timeDiff = epicsTimeDiffInSeconds(&currTime, &remount_check_time);
+    if (timeDiff > REMOUNT_CHECK_INTERVAL_SECONDS) {
+        remount_check_time = currTime; /* struct copy */
+        printf("save_restore: attempting to remount filesystem\n");
+        dismountFileSystem(save_restoreNFSMntPoint); /* first dismount it */
+        /* We don't care if dismountFileSystem fails.
+         * It could fail simply because an earlier dismount, succeeded.
+         */
+        if (mountFileSystem(save_restoreNFSHostName, save_restoreNFSHostAddr, save_restoreNFSMntPoint,
+                            save_restoreNFSMntPoint) == OK) {
+            *just_remounted = 1;
+            printf("save_restore: remounted '%s'\n", save_restoreNFSMntPoint);
+        } else {
+            printf("save_restore: failed to remount '%s' \n", save_restoreNFSMntPoint);
+            return ERROR;
+        }
+    }
+    return OK;
+}
+
+int set_savefile_path_nfs()
+{
+    if (mountFileSystem(save_restoreNFSHostName, save_restoreNFSHostAddr, save_restoreNFSMntPoint,
+                        save_restoreNFSMntPoint) == OK) {
+        printf("save_restore:mountFileSystem:successfully mounted '%s'\n", save_restoreNFSMntPoint);
+        return OK;
+    }
+    printf("save_restore: Can't mount '%s'\n", save_restoreNFSMntPoint);
+    return ERROR;
+}
+
+void save_restoreSet_NFSHost(char *hostname, char *address, char *mntpoint)
+{
+    /* If file system is mounted (save_restoreNFSOK) and we mounted it (save_restoreNFSMntPoint[0]),
+     * then dismount, presuming that caller wants us to remount from new information.  If we didn't
+     * mount it, presume that caller did, and that caller wants us to manage the mount point.
+     */
+    if (save_restoreNFSOK && save_restoreNFSMntPoint[0]) dismountFileSystem(save_restoreNFSMntPoint);
+
+    /* get the settings */
+    strNcpy(save_restoreNFSHostName, hostname, NFS_PATH_LEN);
+    strNcpy(save_restoreNFSHostAddr, address, NFS_PATH_LEN);
+    if (mntpoint && mntpoint[0]) {
+        saveRestoreFilePathIsMountPoint = 0;
+        strNcpy(save_restoreNFSMntPoint, mntpoint, NFS_PATH_LEN);
+        if (saveRestoreFilePath[0]) {
+            /* If we already have a file path, make sure it begins with the mount point. */
+            if (strstr(saveRestoreFilePath, save_restoreNFSMntPoint) != saveRestoreFilePath) {
+                makeNfsPath(saveRestoreFilePath, save_restoreNFSMntPoint, saveRestoreFilePath);
+            }
+        }
+    } else if (saveRestoreFilePath[0]) {
+        strNcpy(save_restoreNFSMntPoint, saveRestoreFilePath, NFS_PATH_LEN);
+        saveRestoreFilePathIsMountPoint = 1;
+    }
+
+    /* mount the file system */
+    do_mount();
+}
+
+IOCSH_ARG save_restoreSet_NFSHost_Arg0 = {"hostname", iocshArgString};
+IOCSH_ARG save_restoreSet_NFSHost_Arg1 = {"address", iocshArgString};
+IOCSH_ARG save_restoreSet_NFSHost_Arg2 = {"mntpoint", iocshArgString};
+IOCSH_ARG_ARRAY save_restoreSet_NFSHost_Args[3] = {&save_restoreSet_NFSHost_Arg0, &save_restoreSet_NFSHost_Arg1,
+                                                   &save_restoreSet_NFSHost_Arg2};
+IOCSH_FUNCDEF save_restoreSet_NFSHost_FuncDef = {"save_restoreSet_NFSHost", 3, save_restoreSet_NFSHost_Args};
+static void save_restoreSet_NFSHost_CallFunc(const iocshArgBuf *args)
+{
+    save_restoreSet_NFSHost(args[0].sval, args[1].sval, args[2].sval);
+}
+
+void save_restoreNFSRegister(void)
+{
+    iocshRegister(&save_restoreSet_NFSHost_FuncDef, save_restoreSet_NFSHost_CallFunc);
+}
+
+epicsExportRegistrar(save_restoreNFSRegister);

--- a/asApp/src/nfs_utils.h
+++ b/asApp/src/nfs_utils.h
@@ -22,4 +22,6 @@ int set_savefile_path_nfs();
 
 void save_restoreSet_NFSHost(char *hostname, char *address, char *mntpoint);
 
+int nfs_managed();
+
 #endif

--- a/asApp/src/nfs_utils.h
+++ b/asApp/src/nfs_utils.h
@@ -1,0 +1,25 @@
+#ifndef NFS_UTILS_H
+#define NFS_UTILS_H
+
+#include "osdNfs.h"
+#include "save_restore_common.h"
+#include <epicsTime.h>
+
+#define REMOUNT_CHECK_INTERVAL_SECONDS 60
+extern char save_restoreNFSHostName[NFS_PATH_LEN];
+extern char save_restoreNFSHostAddr[NFS_PATH_LEN];
+extern char save_restoreNFSMntPoint[NFS_PATH_LEN];
+extern int saveRestoreFilePathIsMountPoint;
+extern volatile int save_restoreRemountThreshold;
+
+extern char saveRestoreFilePath[NFS_PATH_LEN];
+
+STATIC int do_mount();
+
+int restore_mount(epicsTimeStamp remount_check_time, int *just_remounted);
+
+int set_savefile_path_nfs();
+
+void save_restoreSet_NFSHost(char *hostname, char *address, char *mntpoint);
+
+#endif

--- a/asApp/src/nfs_utils.h
+++ b/asApp/src/nfs_utils.h
@@ -8,7 +8,6 @@
 extern char save_restoreNFSHostName[NFS_PATH_LEN];
 extern char save_restoreNFSHostAddr[NFS_PATH_LEN];
 extern char save_restoreNFSMntPoint[NFS_PATH_LEN];
-extern int saveRestoreFilePathIsMountPoint;
 extern volatile int save_restoreRemountThreshold;
 
 extern char saveRestoreFilePath[NFS_PATH_LEN];
@@ -19,8 +18,8 @@ int restore_mount(epicsTimeStamp remount_check_time, int *just_remounted);
 
 int set_savefile_path_nfs();
 
-void save_restoreSet_NFSHost(char *hostname, char *address, char *mntpoint);
-
 int nfs_managed();
+
+void save_restore_nfs_show();
 
 #endif

--- a/asApp/src/nfs_utils.h
+++ b/asApp/src/nfs_utils.h
@@ -1,7 +1,6 @@
 #ifndef NFS_UTILS_H
 #define NFS_UTILS_H
 
-#include "osdNfs.h"
 #include "save_restore_common.h"
 #include <epicsTime.h>
 

--- a/asApp/src/save_restore.c
+++ b/asApp/src/save_restore.c
@@ -652,7 +652,7 @@ int findConfigFiles(char *config, ELLLIST *configMenuList)
                     pLI->name = (char *)calloc(strlen(thisname) + 1, sizeof(char));
                     strNcpy(pLI->name, thisname, strlen(thisname) + 1);
                     if (save_restoreDebug) printf("findConfigFiles: found config file '%s'\n", pLI->name);
-                    makeNfsPath(fullpath, saveRestoreFilePath, filename);
+                    concatenate_paths(fullpath, saveRestoreFilePath, filename);
                     if ((fd = fopen(fullpath, "r"))) {
                         if (save_restoreDebug) printf("findConfigFiles: searching '%s' for description\n", fullpath);
                         found = 0;
@@ -732,9 +732,9 @@ STATIC void ca_connection_callback(struct connection_handler_args args)
 
 /* Concatenate s1 and s2, making sure there is a directory separator between them,
  * and copy the result to dest.  Make local copies of s1 and s2 to defend against
- * calls in which one of them is specified also as dest, e.g. makeNfsPath(a,b,a).
+ * calls in which one of them is specified also as dest, e.g. concatenate_paths(a,b,a).
  */
-void makeNfsPath(char *dest, const char *s1, const char *s2)
+void concatenate_paths(char *dest, const char *s1, const char *s2)
 {
     char tmp1[NFS_PATH_LEN], tmp2[NFS_PATH_LEN];
     if (dest == NULL) return;
@@ -752,36 +752,36 @@ void makeNfsPath(char *dest, const char *s1, const char *s2)
     } else {
         strncat(dest, tmp2, MAX(NFS_PATH_LEN - 1 - strlen(dest), 0));
     }
-    if (save_restoreDebug > 2) { printf("save_restore:makeNfsPath: dest='%s'\n", dest); }
+    if (save_restoreDebug > 2) { printf("save_restore:concatenate_paths: dest='%s'\n", dest); }
 }
 
-int testMakeNfsPath()
+int test_concatenate_path()
 {
     char dest[NFS_PATH_LEN];
 
     dest[0] = '\0';
-    makeNfsPath(dest, "", "");
-    printf("makeNfsPath(dest,\"\",\"\") yields '%s'\n", dest);
+    concatenate_paths(dest, "", "");
+    printf("concatenate_paths(dest,\"\",\"\") yields '%s'\n", dest);
 
     dest[0] = '\0';
-    makeNfsPath(dest, "abc", "");
-    printf("makeNfsPath(dest,\"abc\",\"\") yields '%s'\n", dest);
+    concatenate_paths(dest, "abc", "");
+    printf("concatenate_paths(dest,\"abc\",\"\") yields '%s'\n", dest);
 
     dest[0] = '\0';
-    makeNfsPath(dest, "", "def");
-    printf("makeNfsPath(dest,\"\",\"def\") yields '%s'\n", dest);
+    concatenate_paths(dest, "", "def");
+    printf("concatenate_paths(dest,\"\",\"def\") yields '%s'\n", dest);
 
     dest[0] = '\0';
-    makeNfsPath(dest, "", "/def");
-    printf("makeNfsPath(dest,\"\",\"/def\") yields '%s'\n", dest);
+    concatenate_paths(dest, "", "/def");
+    printf("concatenate_paths(dest,\"\",\"/def\") yields '%s'\n", dest);
 
     dest[0] = '\0';
-    makeNfsPath(dest, "abc/", "def");
-    printf("makeNfsPath(dest,\"abc/\",\"def\") yields '%s'\n", dest);
+    concatenate_paths(dest, "abc/", "def");
+    printf("concatenate_paths(dest,\"abc/\",\"def\") yields '%s'\n", dest);
 
     dest[0] = '\0';
-    makeNfsPath(dest, "abc/", "/def");
-    printf("makeNfsPath(dest,\"abc/\",\"/def\") yields '%s'\n", dest);
+    concatenate_paths(dest, "abc/", "/def");
+    printf("concatenate_paths(dest,\"abc/\",\"/def\") yields '%s'\n", dest);
     return (0);
 }
 
@@ -1167,7 +1167,7 @@ STATIC int save_restore(void)
                                   status ? "Failed" : "Succeeded");
                     if (status == 0) {
                         if (!isAbsolute(msg.filename)) {
-                            makeNfsPath(fullPath, saveRestoreFilePath, msg.filename);
+                            concatenate_paths(fullPath, saveRestoreFilePath, msg.filename);
                         } else {
                             strNcpy(fullPath, msg.filename, NFS_PATH_LEN);
                         }
@@ -1254,7 +1254,7 @@ STATIC int save_restore(void)
                 case op_asVerify:
                     if (save_restoreDebug) printf("save_restore task: calling do_asVerify('%s')\n", msg.filename);
                     if (!isAbsolute(msg.filename)) {
-                        makeNfsPath(fullPath, saveRestoreFilePath, msg.filename);
+                        concatenate_paths(fullPath, saveRestoreFilePath, msg.filename);
                     } else {
                         strNcpy(fullPath, msg.filename, NFS_PATH_LEN);
                     }
@@ -1961,22 +1961,22 @@ STATIC int write_save_file(struct chlist *plist, const char *configName, char *r
         ca_pend_io(1.0);
         if (tmpstr[0] == '\0') return (OK);
         strNcpy(save_file, tmpstr, sizeof(save_file));
-        if (!isAbsolute(save_file)) { makeNfsPath(save_file, saveRestoreFilePath, save_file); }
+        if (!isAbsolute(save_file)) { concatenate_paths(save_file, saveRestoreFilePath, save_file); }
     } else {
         /* Use standard path name. */
         strNcpy(save_file, saveRestoreFilePath, sizeof(save_file));
     }
     if (configName && configName[0]) {
-        makeNfsPath(save_file, save_file, configName);
+        concatenate_paths(save_file, save_file, configName);
     } else if (plist->saveNamePV_chid) {
         /* This list's file name comes from a PV */
         ca_array_get(DBR_STRING, 1, plist->saveNamePV_chid, tmpstr);
         ca_pend_io(1.0);
         if (tmpstr[0] == '\0') return (OK);
-        makeNfsPath(save_file, save_file, tmpstr);
+        concatenate_paths(save_file, save_file, tmpstr);
     } else {
         /* Use file name constructed from the request file name. */
-        makeNfsPath(save_file, save_file, plist->save_file);
+        concatenate_paths(save_file, save_file, plist->save_file);
     }
 
     /* Currently, all lists do backups, unless their file path or file name comes from a PV, or the configName argument. */
@@ -2090,7 +2090,7 @@ STATIC void do_seq(struct chlist *plist)
     fGetDateStr(datetime);
 
     /* Make full file names */
-    makeNfsPath(save_file, saveRestoreFilePath, plist->save_file);
+    concatenate_paths(save_file, saveRestoreFilePath, plist->save_file);
     strNcpy(backup_file, save_file, NFS_PATH_LEN);
     p = &backup_file[strlen(backup_file)];
 
@@ -2160,7 +2160,7 @@ STATIC void doPeriodicDatedBackup(struct chlist *plist)
         ca_pend_io(1.0);
         if (tmpstr[0] == '\0') return;
         strNcpy(save_file, tmpstr, sizeof(save_file));
-        if (!isAbsolute(save_file)) { makeNfsPath(save_file, saveRestoreFilePath, save_file); }
+        if (!isAbsolute(save_file)) { concatenate_paths(save_file, saveRestoreFilePath, save_file); }
     } else {
         /* Use standard path name. */
         strNcpy(save_file, saveRestoreFilePath, sizeof(save_file));
@@ -2171,10 +2171,10 @@ STATIC void doPeriodicDatedBackup(struct chlist *plist)
         ca_array_get(DBR_STRING, 1, plist->saveNamePV_chid, tmpstr);
         ca_pend_io(1.0);
         if (tmpstr[0] == '\0') return;
-        makeNfsPath(save_file, save_file, tmpstr);
+        concatenate_paths(save_file, save_file, tmpstr);
     } else {
         /* Use file name constructed from the request file name. */
-        makeNfsPath(save_file, save_file, plist->save_file);
+        concatenate_paths(save_file, save_file, plist->save_file);
     }
 
     strncat(save_file, "_b_", sizeof(save_file) - strlen(save_file) - 1);
@@ -2377,7 +2377,7 @@ STATIC int create_data_set(char *filename,              /* save set request file
     plist->save_file[inx] = 0; /* truncate if necessary to leave room for ".sav" + null */
     strcat(plist->save_file, ".sav");
     /* make full name, including file path */
-    makeNfsPath(plist->saveFile, saveRestoreFilePath, plist->save_file);
+    concatenate_paths(plist->saveFile, saveRestoreFilePath, plist->save_file);
 
     /* read the request file and populate plist with the PV names */
     if (readReqFile(plist->reqFile, plist, macrostring) == ERROR) {
@@ -2520,7 +2520,7 @@ int set_requestfile_path(char *path, char *pathsub)
         return (ERROR);
     }
 
-    makeNfsPath(fullpath, path, pathsub);
+    concatenate_paths(fullpath, path, pathsub);
 
     if (*fullpath) {
         /* return(set_requestfile_path(fullpath)); */
@@ -2552,14 +2552,14 @@ int set_savefile_path(char *path, char *pathsub)
 
     if (save_restoreNFSOK && NFS_managed) dismountFileSystem(save_restoreNFSMntPoint);
 
-    makeNfsPath(fullpath, path, pathsub);
+    concatenate_paths(fullpath, path, pathsub);
 
     if (*fullpath) {
         if (saveRestoreFilePathIsMountPoint) {
             strNcpy(saveRestoreFilePath, fullpath, NFS_PATH_LEN);
             strNcpy(save_restoreNFSMntPoint, fullpath, NFS_PATH_LEN);
         } else {
-            makeNfsPath(saveRestoreFilePath, save_restoreNFSMntPoint, fullpath);
+            concatenate_paths(saveRestoreFilePath, save_restoreNFSMntPoint, fullpath);
         }
         if (NFS_managed && (set_savefile_path_nfs() == OK)) {
             // TODO: Probably should set SR_status here?
@@ -3209,7 +3209,7 @@ STATIC int do_manual_restore(char *filename, int file_type, char *macrostring)
     if (isAbsolute(filename)) {
         strNcpy(restoreFile, filename, NFS_PATH_LEN);
     } else {
-        makeNfsPath(restoreFile, saveRestoreFilePath, filename);
+        concatenate_paths(restoreFile, saveRestoreFilePath, filename);
     }
 
     if (file_type == FROM_SAVE_FILE) {
@@ -3430,7 +3430,7 @@ int openReqFile(const char *reqFile, FILE **fpp)
     if (reqFilePathList) {
         /* try to find reqFile in every directory specified in reqFilePathList */
         for (p = reqFilePathList; p; p = p->pnext) {
-            makeNfsPath(tmpfile, p->path, reqFile);
+            concatenate_paths(tmpfile, p->path, reqFile);
             trial_fd = fopen(tmpfile, "r");
             if (trial_fd) break;
         }

--- a/asApp/src/save_restore.c
+++ b/asApp/src/save_restore.c
@@ -754,36 +754,6 @@ void concatenate_paths(char *dest, const char *s1, const char *s2)
     if (save_restoreDebug > 2) { printf("save_restore:concatenate_paths: dest='%s'\n", dest); }
 }
 
-int test_concatenate_path()
-{
-    char dest[MAX_PATH_LEN];
-
-    dest[0] = '\0';
-    concatenate_paths(dest, "", "");
-    printf("concatenate_paths(dest,\"\",\"\") yields '%s'\n", dest);
-
-    dest[0] = '\0';
-    concatenate_paths(dest, "abc", "");
-    printf("concatenate_paths(dest,\"abc\",\"\") yields '%s'\n", dest);
-
-    dest[0] = '\0';
-    concatenate_paths(dest, "", "def");
-    printf("concatenate_paths(dest,\"\",\"def\") yields '%s'\n", dest);
-
-    dest[0] = '\0';
-    concatenate_paths(dest, "", "/def");
-    printf("concatenate_paths(dest,\"\",\"/def\") yields '%s'\n", dest);
-
-    dest[0] = '\0';
-    concatenate_paths(dest, "abc/", "def");
-    printf("concatenate_paths(dest,\"abc/\",\"def\") yields '%s'\n", dest);
-
-    dest[0] = '\0';
-    concatenate_paths(dest, "abc/", "/def");
-    printf("concatenate_paths(dest,\"abc/\",\"/def\") yields '%s'\n", dest);
-    return (0);
-}
-
 static void save_restoreShutdown(void *arg)
 {
     save_restore_shutdown = 1;

--- a/asApp/src/save_restore.c
+++ b/asApp/src/save_restore.c
@@ -806,7 +806,7 @@ STATIC int save_restore(void)
     epicsTimeStamp lastPeriodicDatedBackup;
     char datetime[32];
     double timeDiff;
-    int NFS_managed = save_restoreNFSHostName[0] && save_restoreNFSHostAddr[0] && save_restoreNFSMntPoint[0];
+    int NFS_managed = nfs_managed();
     op_msg msg;
     struct restoreFileListItem *pLI;
 
@@ -2419,7 +2419,6 @@ void save_restoreShow(int verbose)
     struct pathListElement *p = reqFilePathList;
     char tmpstr[50];
     char datetime[32];
-    int NFS_managed = save_restoreNFSHostName[0] && save_restoreNFSHostAddr[0] && save_restoreNFSMntPoint[0];
 
     fGetDateStr(datetime);
     printf("BEGIN save_restoreShow\n");
@@ -2434,10 +2433,9 @@ void save_restoreShow(int verbose)
     printf("  Number of sequence files to maintain: %d\n", save_restoreNumSeqFiles);
     printf("  Time interval between sequence files: %d seconds\n", save_restoreSeqPeriodInSeconds);
     printf("  Time interval between .sav-file write failure and retry: %d seconds\n", save_restoreRetrySeconds);
-    printf("  NFS host: '%s'; address:'%s'\n", save_restoreNFSHostName, save_restoreNFSHostAddr);
-    printf("  NFS mount point:\n    '%s'\n", save_restoreNFSMntPoint);
-    printf("  NFS mount status: %s\n",
-           NFS_managed ? (save_restoreNFSOK ? "Ok" : "Failed") : "not managed by save_restore");
+    if (nfs_managed()) {
+        save_restore_nfs_show();
+    }
     printf("  I/O errors: %d\n", save_restoreIoErrors);
     printf("  request file path list:\n");
     while (p) {
@@ -2548,7 +2546,7 @@ int set_requestfile_path(char *path, char *pathsub)
 int set_savefile_path(char *path, char *pathsub)
 {
     char fullpath[NFS_PATH_LEN] = "";
-    int NFS_managed = save_restoreNFSHostName[0] && save_restoreNFSHostAddr[0] && save_restoreNFSMntPoint[0];
+    int NFS_managed = nfs_managed();
 
     if (save_restoreNFSOK && NFS_managed) dismountFileSystem(save_restoreNFSMntPoint);
 

--- a/asApp/src/save_restore.c
+++ b/asApp/src/save_restore.c
@@ -2545,23 +2545,10 @@ int set_requestfile_path(char *path, char *pathsub)
 int set_savefile_path(char *path, char *pathsub)
 {
     char fullpath[MAX_PATH_LEN] = "";
-    int NFS_managed = nfs_managed();
-
-    if (save_restoreNFSOK && NFS_managed) dismountFileSystem(save_restoreNFSMntPoint);
-
     concatenate_paths(fullpath, path, pathsub);
 
     if (*fullpath) {
-        if (saveRestoreFilePathIsMountPoint) {
-            strNcpy(saveRestoreFilePath, fullpath, MAX_PATH_LEN);
-            strNcpy(save_restoreNFSMntPoint, fullpath, MAX_PATH_LEN);
-        } else {
-            concatenate_paths(saveRestoreFilePath, save_restoreNFSMntPoint, fullpath);
-        }
-        if (NFS_managed && (set_savefile_path_nfs() == OK)) {
-            // TODO: Probably should set SR_status here?
-            strNcpy(SR_recentlyStr, "mountFileSystem succeeded", STATUS_STR_LEN);
-        }
+		strNcpy(saveRestoreFilePath, fullpath, MAX_PATH_LEN);
         return (OK);
     } else {
         return (ERROR);

--- a/asApp/src/save_restore.h
+++ b/asApp/src/save_restore.h
@@ -2,15 +2,7 @@
 
 #include <ellLib.h> /* pass0List, pass1List */
 #include <initHooks.h>
-
-#define STATIC_VARS 0
-#define DEBUG 1
-
-#if STATIC_VARS
-#define STATIC static
-#else
-#define STATIC
-#endif
+#include "save_restore_common.h"
 
 #define TATTLE(CA_ERROR_CODE, FMT, ARG)                                           \
     {                                                                             \
@@ -37,14 +29,14 @@
 #define MAX(a, b) ((a) > (b) ? (a) : (b))
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
+/* Make sure to leave room for trailing null */
+static char SR_STATUS_STR[5][10] = {"No Status", " Failure ", " Warning ", " Warning ", "    Ok   "};
+
 #define SR_STATUS_OK 4
 #define SR_STATUS_SEQ_WARN 3
 #define SR_STATUS_WARN 2
 #define SR_STATUS_FAIL 1
 #define SR_STATUS_INIT 0
-
-/* Make sure to leave room for trailing null */
-static char SR_STATUS_STR[5][10] = {"No Status", " Failure ", " Warning ", " Warning ", "    Ok   "};
 
 #define FLOAT_FMT "%.7g"
 #define DOUBLE_FMT "%.14g"
@@ -97,11 +89,8 @@ extern volatile int save_restoreDatedBackupFiles;
 extern struct restoreList restoreFileList;
 extern int myFileCopy(const char *source, const char *dest);
 extern void dbrestoreShow(void);
-extern void makeNfsPath(char *dest, const char *s1, const char *s2);
 extern int do_asVerify(char *fileName, int verbose, int debug, int write_restore_file, char *restoreFileName);
 
-extern int save_restoreNFSOK;
-extern int save_restoreIoErrors;
 extern volatile int save_restoreRemountThreshold;
 
 extern int reboot_restore(char *filename, initHookState init_state);
@@ -114,14 +103,3 @@ extern int openReqFile(const char *reqFile, FILE **fpp);
 extern int eraseFile(const char *filename);
 extern int appendToFile(const char *filename, const char *line);
 extern float mySafeDoubleToFloat(double d);
-
-/* strncpy sucks (may copy extra characters, may not null-terminate) */
-#define strNcpy(dest, src, N)                                    \
-    {                                                            \
-        int ii;                                                  \
-        char *dd = dest;                                         \
-        const char *ss = src;                                    \
-        if (dd && ss)                                            \
-            for (ii = 0; *ss && ii < N - 1; ii++) *dd++ = *ss++; \
-        *dd = '\0';                                              \
-    }

--- a/asApp/src/save_restore_common.h
+++ b/asApp/src/save_restore_common.h
@@ -1,0 +1,33 @@
+#ifndef SR_COMMON_H
+#define SR_COMMON_H
+
+#define STATIC_VARS 0
+#define DEBUG 1
+
+#if STATIC_VARS
+#define STATIC static
+#else
+#define STATIC
+#endif
+
+#define IOCSH_ARG static const iocshArg
+#define IOCSH_ARG_ARRAY static const iocshArg *const
+#define IOCSH_FUNCDEF static const iocshFuncDef
+
+extern int save_restoreNFSOK;
+extern int save_restoreIoErrors;
+
+extern void makeNfsPath(char *dest, const char *s1, const char *s2);
+
+/* strncpy sucks (may copy extra characters, may not null-terminate) */
+#define strNcpy(dest, src, N)                                    \
+    {                                                            \
+        int ii;                                                  \
+        char *dd = dest;                                         \
+        const char *ss = src;                                    \
+        if (dd && ss)                                            \
+            for (ii = 0; *ss && ii < N - 1; ii++) *dd++ = *ss++; \
+        *dd = '\0';                                              \
+    }
+
+#endif

--- a/asApp/src/save_restore_common.h
+++ b/asApp/src/save_restore_common.h
@@ -17,7 +17,7 @@
 extern int save_restoreNFSOK;
 extern int save_restoreIoErrors;
 
-extern void makeNfsPath(char *dest, const char *s1, const char *s2);
+extern void concatenate_paths(char *dest, const char *s1, const char *s2);
 
 /* strncpy sucks (may copy extra characters, may not null-terminate) */
 #define strNcpy(dest, src, N)                                    \

--- a/asApp/src/save_restore_common.h
+++ b/asApp/src/save_restore_common.h
@@ -1,6 +1,8 @@
 #ifndef SR_COMMON_H
 #define SR_COMMON_H
 
+#include "osdNfs.h"
+
 #define STATIC_VARS 0
 #define DEBUG 1
 
@@ -9,6 +11,8 @@
 #else
 #define STATIC
 #endif
+
+#define MAX_PATH_LEN NFS_PATH_LEN
 
 #define IOCSH_ARG static const iocshArg
 #define IOCSH_ARG_ARRAY static const iocshArg *const


### PR DESCRIPTION
This pull request is a first attempt at cleaning up some of the code in save_restore.c. It seems much more logical that save_restore is aware of reading and writing files, not specifically how and when to mount or unmount an NFS share.

Note that this PR does contain a breaking change: previously it was possible to have the following two lines in any order in a startup script:
```
set_savefile_path foo bar
save_restoreSet_NFSHost hostname port
```
The way this behaved was that if you set the savefile path first, it stored it in memory and then would mount the host:port combination at that specified mountpoint (foo/bar in this case), as no mount point was specified.

If you reversed the order:
```
save_restoreSet_NFSHost hostname port
set_savefile_path foo bar
```
then running `set_savefile_path` would actually mount host:port at the mountpoint foo/bar. This resulted in (IMO) needlessly complicated and confusing code, which is much simplified by enforcing that a mountpoint is specified _before_ attempting to mount; after this change this can be done either by running `set_savefile_path` first, or by specifying the mount point as the third argument to `save_restoreSet_NFSHost`.